### PR TITLE
make executor anim set and string safe

### DIFF
--- a/Executor_anim.tla
+++ b/Executor_anim.tla
@@ -32,8 +32,7 @@ TaskLabel(t) ==
 
 ExecutorCardColor(e) == IF terminated[e] THEN "#bbf7d0" ELSE "#e5e7eb"
 
-PreferredExecutors == {e \in Executors: e \in {1, 2}}
-ExecutorSet == IF PreferredExecutors # {} THEN PreferredExecutors ELSE Executors
+ExecutorSet == Executors
 ExecCount == Cardinality(ExecutorSet)
 
 RECURSIVE SetToSeqSafe(_)


### PR DESCRIPTION
* to avoid `Error evaluating animation view expression` in [AnimView](https://will62794.github.io/spectacle/#!/home?specpath=https%3A%2F%2Fraw.githubusercontent.com%2Fmmsqe%2Fblockstm-spec%2F3ea774ad9a989d9443f7ba253037fefdb86a596a%2FExecutor.tla&initPred=Init&nextPred=Next&constants%5BKey%5D=%7B%22k1%22%7D&constants%5BNoVal%5D=NoVal&constants%5BNoTask%5D=NoTask&constants%5BBlockSize%5D=5&constants%5BExecutors%5D=%7B%221%22%2C%222%22%7D)
* remote spec URLs works while local_dir still need https://github.com/will62794/spectacle/pull/82